### PR TITLE
fix OptimWrapper input params

### DIFF
--- a/_notebooks/2021-02-14-Pytorchtofastai.ipynb
+++ b/_notebooks/2021-02-14-Pytorchtofastai.ipynb
@@ -356,7 +356,7 @@
         "id": "zA6xlSYMNhbo"
       },
       "source": [
-        "def opt_func(params, **kwargs): return OptimWrapper(optim.SGD(params, lr=0.001))"
+        "def opt_func(params, **kwargs): return OptimWrapper(params, torch.optim.SGD, **kwargs)"
       ],
       "execution_count": 11,
       "outputs": []


### PR DESCRIPTION
This does not work with the latest version of OptimWrapper. This PR updates the input parameters so it now works.